### PR TITLE
fix: use dynamic id for `aria-controls` in `PasswordToggle.vue`

### DIFF
--- a/src/runtime/components/input/PasswordToggle.vue
+++ b/src/runtime/components/input/PasswordToggle.vue
@@ -1,14 +1,16 @@
 <script setup lang="ts">
 import UButton from '@nuxt/ui/components/Button.vue'
 import UInput from '@nuxt/ui/components/Input.vue'
-import { ref } from 'vue'
+import { ref, useId } from 'vue'
 
 const show = ref(false)
 const input = defineModel<string>({ default: '' })
+const inputId = useId()
 </script>
 
 <template>
   <UInput
+    :id="inputId"
     v-model="input"
     :type="show ? 'text' : 'password'"
     :ui="{ trailing: 'pe-1' }"
@@ -21,7 +23,7 @@ const input = defineModel<string>({ default: '' })
         :icon="show ? 'i-lucide-eye-off' : 'i-lucide-eye'"
         :aria-label="show ? 'Hide password' : 'Show password'"
         :aria-pressed="show"
-        aria-controls="password"
+        :aria-controls="inputId"
         @click="show = !show"
       />
     </template>


### PR DESCRIPTION
Closes #35

`aria-controls="password"` in PasswordToggle.vue referenced a hardcoded element id that didn't exist in the DOM causing accessibility violations flagged by lighthouse.

Fixed by generating a unique ID with Vue's `useId()` composable and binding it both to the `UInput` element and `aria-controls`, so the button correctly points to the actual input it controls